### PR TITLE
Fix TiDE forward initialisation to use ForwardSelection step helper

### DIFF
--- a/feature_selections/heuristics/population_based/tide.py
+++ b/feature_selections/heuristics/population_based/tide.py
@@ -89,22 +89,14 @@ class Tide(Heuristic):
             output=None,
             strat="sffs" if self.sffs_init else "sfs"
         )
-        fs.selected_features = []
         scoreMax, indMax, G = -np.inf, np.zeros(self.D, dtype=int), 0
         improvement = True
         while G < self.Gmax and improvement:
-            if self.sffs_init:
-                improvement, _, scoreMax, indMax, timeout = fs._forward_backward_step(
-                    scoreMax=scoreMax,
-                    indMax=indMax,
-                    start_time=debut
-                )
-            else:
-                improvement, _, scoreMax, indMax, timeout = fs._forward_step(
-                    scoreMax=scoreMax,
-                    indMax=indMax,
-                    start_time=debut
-                )
+            improvement, _, scoreMax, indMax, timeout = fs.step(
+                scoreMax=scoreMax,
+                indMax=indMax,
+                start_time=debut,
+            )
             G = G + 1
             if timeout or time.time() - debut >= self.Tmax:
                 break

--- a/feature_selections/heuristics/single_solution/forward.py
+++ b/feature_selections/heuristics/single_solution/forward.py
@@ -121,6 +121,14 @@ class ForwardSelection(Heuristic):
         overall_improvement = overall_improvement or bwd_impr
         return overall_improvement, self.selected_features, scoreMax, indMax, timeout
 
+    def step(self, scoreMax, indMax, start_time=None):
+        """Run a single optimisation step according to the configured strategy."""
+        if start_time is None:
+            start_time = time.time()
+        if self.strat == "sfs":
+            return self._forward_step(scoreMax=scoreMax, indMax=indMax, start_time=start_time)
+        return self._forward_backward_step(scoreMax=scoreMax, indMax=indMax, start_time=start_time)
+
     def start(self, pid):
         code = "SFS " if self.strat == "sfs" else "SFFS"
         debut = time.time()


### PR DESCRIPTION
## Summary
- add a public `ForwardSelection.step` helper that reuses the existing forward and forward-backward steps
- update TiDE forward initialisation to rely on the new helper while keeping the best-indicator behaviour

## Testing
- `pytest tests/test_forward_selection.py -k "tide_forward_initialisation" -q`


------
https://chatgpt.com/codex/tasks/task_e_68ceb8ac97fc8332a809be158360b045