### PR TITLE
Fix TiDE SFFS initialisation

### DIFF
--- a/feature_selections/heuristics/population_based/tide.py
+++ b/feature_selections/heuristics/population_based/tide.py
@@ -91,8 +91,12 @@ class Tide(Heuristic):
         )
         scoreMax, indMax, G = -np.inf, np.zeros(self.D, dtype=int), 0
         improvement = True
+        if self.sffs_init:
+            step_fn = fs._forward_backward_step
+        else:
+            step_fn = fs._forward_step
         while G < self.Gmax and improvement:
-            improvement, _, scoreMax, indMax, timeout = fs.step(
+            improvement, _, scoreMax, indMax, timeout = step_fn(
                 scoreMax=scoreMax,
                 indMax=indMax,
                 start_time=debut,


### PR DESCRIPTION
## Summary
- reuse ForwardSelection's internal forward/backward logic when seeding TiDE
- ensure both SFS and SFFS seeds call the appropriate private step implementation

## Testing
- pytest tests/test_forward_selection.py::test_tide_forward_initialisation_returns_best_indicator -q

------
https://chatgpt.com/codex/tasks/task_e_68cebd480e7c8332b806dd862ffc9118